### PR TITLE
update deployer address

### DIFF
--- a/docs/tutorials/clarity-nft.md
+++ b/docs/tutorials/clarity-nft.md
@@ -128,7 +128,8 @@ following code into the file.
 
 ```clarity
 ;; use the SIP090 interface (testnet)
-(impl-trait 'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.nft-trait.nft-trait)
+(impl-trait 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.nft-trait.nft-trait)
+
 
 ;; define a new NFT. Make sure to replace MY-OWN-NFT
 (define-non-fungible-token MY-OWN-NFT uint)

--- a/docs/tutorials/clarity-nft.md
+++ b/docs/tutorials/clarity-nft.md
@@ -128,8 +128,8 @@ following code into the file.
 
 ```clarity
 ;; use the SIP090 interface (testnet)
+;; trait deployed by deployer address from ./settings/Devnet.toml
 (impl-trait 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.nft-trait.nft-trait)
-
 
 ;; define a new NFT. Make sure to replace MY-OWN-NFT
 (define-non-fungible-token MY-OWN-NFT uint)


### PR DESCRIPTION
## Description

before this change I was getting this error on going through the [tutorial-nft](https://docs.hiro.so/tutorials/clarity-nft)

```
➜  clarity git:(main) ✗ clarinet check

Error found in contract astro-nft
Analysis error: use of undeclared trait <nft-trait>
```

per lnow#4130 in Discord conversation in Stacks server here
https://discord.com/channels/621759717756370964/713087894260023377/908931002058035201

> Few versions ago address of deployer account used in Clarinet has been changed.


An address change to example code in the tutorial-nft.
One of the tutorials has an address incorrect. This is very hard for a newbie to understand or debug, someone in Discord gave me the new incantation. 

Change:
`(impl-trait 'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.nft-trait.nft-trait)`

to:
`(impl-trait 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.nft-trait.nft-trait)`
Few versions ago address of deployer account used in Clarinet has been changed.

ie from:  
https://explorer.stacks.co/address/ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE?chain=testnet

to:   

https://explorer.stacks.co/address/ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM?chain=testnet

## Checklist

- [X] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] New links to files and images were verified
- [X] For fixes/refactors: all existing references were identified and replaced
- [X] [Style guide](https://developers.google.com/style) was reviewed and applied
- [X] Clear code samples were provided
- [X] People were tagged for review

will tag reviewers once PR is in upstream repo